### PR TITLE
Update spoke_transit_att's spoke_gw_name ref to id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,14 +79,14 @@ resource "aviatrix_spoke_gateway" "default" {
 
 resource "aviatrix_spoke_transit_attachment" "default" {
   count           = var.attached ? 1 : 0
-  spoke_gw_name   = aviatrix_spoke_gateway.default.gw_name
+  spoke_gw_name   = aviatrix_spoke_gateway.default.id
   transit_gw_name = var.transit_gw
   route_tables    = var.transit_gw_route_tables
 }
 
 resource "aviatrix_spoke_transit_attachment" "transit_gw_egress" {
   count           = length(var.transit_gw_egress) > 0 ? (var.attached_gw_egress ? 1 : 0) : 0
-  spoke_gw_name   = aviatrix_spoke_gateway.default.gw_name
+  spoke_gw_name   = aviatrix_spoke_gateway.default.id
   transit_gw_name = var.transit_gw_egress
   route_tables    = var.transit_gw_egress_route_tables
 }


### PR DESCRIPTION
By changing this reference, since `.id` is the same as the `gw_name` in spoke, this maintains original workflow while also supporting better lifecycle dependency resolutions.

- ORIGINAL: if the spoke is already attached to transit, and an update to the spoke causes spoke to be replaced, it will fail, since spoke must be detached first
- NEW: updating spoke where it will be replaced, will cause the spoke-transit-attachment resource to also be destroyed. (resolves dependency issue)