### PR TITLE
add support for custom gateway name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aviatrix_vpc" "default" {
 resource "aviatrix_spoke_gateway" "default" {
   cloud_type                            = local.cloud_type
   vpc_reg                               = local.region
-  gw_name                               = local.name
+  gw_name                               = local.gw_name
   gw_size                               = local.instance_size
   vpc_id                                = var.use_existing_vpc ? var.vpc_id : aviatrix_vpc.default[0].vpc_id
   account_name                          = var.account

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,23 @@ variable "name" {
   }
 }
 
+variable "gw_name" {
+  description = "Name for the transit gateway"
+  type        = string
+  default     = ""
+  nullable    = false
+
+  validation {
+    condition     = length(var.gw_name) <= 50
+    error_message = "Name is too long. Max length is 50 characters."
+  }
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-_]*$", var.gw_name))
+    error_message = "Only a-z, A-Z, 0-9 and hyphens and underscores are allowed."
+  }
+}
+
 variable "region" {
   description = "The region to deploy this module in"
   type        = string
@@ -400,6 +417,7 @@ variable "enable_preserve_as_path" {
 locals {
   cloud                 = lower(var.cloud)
   name                  = replace(var.name, " ", "-")                     #Replace spaces with dash
+  gw_name               = coalesce(var.gw_name, local.name)
   cidr                  = var.use_existing_vpc ? "10.0.0.0/20" : var.cidr #Set dummy if existing VPC is used.
   cidrbits              = tonumber(split("/", local.cidr)[1])
   newbits               = 26 - local.cidrbits


### PR DESCRIPTION
module "test_spoke_azure_weu" {
  source  = "./terraform-aviatrix-mc-spoke"


  cloud           = "Azure"
  name            = "test-vpc"
  gw_name         = "test-gw"
  cidr            = "10.11.0.0/24"
  region          = "West Europe"
  account         = "azure-acc-tf"
  transit_gw      = "AZWEUAVTXGW01"
}

module.test_spoke_azure_weu.aviatrix_spoke_transit_attachment.default[0]: Creating...
module.test_spoke_azure_weu.aviatrix_spoke_transit_attachment.default[0]: Still creating... [10s elapsed]
module.test_spoke_azure_weu.aviatrix_spoke_transit_attachment.default[0]: Still creating... [20s elapsed]
module.test_spoke_azure_weu.aviatrix_spoke_transit_attachment.default[0]: Creation complete after 26s [id=test-gw~AZWEUAVTXGW01]

Apply complete! Resources: 3 added, 0 changed, 2 destroyed.

raga@Ragas-MacBook-Pro change_spoke_module % terraform console
> nonsensitive(module.test_spoke_azure_weu.spoke_gateway.gw_name)
"test-gw"
> (module.test_spoke_azure_weu.vpc.id)
"test-vpc"
> exit
raga@Ragas-MacBook-Pro change_spoke_module % 

