### PR TITLE
change HPE instance size and add AWS example for group mode + insane …

### DIFF
--- a/examples/aws_group_mode_insane_mode_existing_vpc/README.md
+++ b/examples/aws_group_mode_insane_mode_existing_vpc/README.md
@@ -1,0 +1,41 @@
+### Usage Example AWS Group Mode insane mode Existing VPC
+
+In this example, the module deploys the Aviatrix spoke gateways in insane mode in an existing VPC.
+
+```hcl
+data "aws_vpc" "example" {
+  id = var.vpc_id
+}
+
+data "aws_subnet" "example_gw" {
+  id = var.gw_subnet_id
+}
+
+data "aws_subnet" "example_hagw" {
+  id = var.hagw_subnet_id
+}
+
+module "spoke_aws_1" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "1.6.5"
+
+  cloud                  = "AWS"
+  name                   = "awsapp1"
+  region                 = "us-east-1"
+  account                = "aws-account"
+  transit_gw             = "avx-us-east-1-tg"
+  vpc_id                 = data.aws_vpc.example.vpc_id
+  gw_subnet              = data.aws_subnet.example_gw.cidr_block
+  hagw_subnet            = data.aws_subnet.example_hagw.cidr_block #Use separate subnets in multiple AZ's for gw and hagw, for multi AZ availability.
+  insane_mode            = true
+  use_existing_vpc       = true
+  inspection             = true
+
+  #Group mode settings 3 GW's, provide the additional subnet CIDR's for spoke gateways 3-n.
+  group_mode                    = true
+  spoke_gw_amount               = 3
+  additional_group_mode_subnets = ["10.1.0.0/26"]
+  additional_group_mode_azs     = ["c"]
+}
+
+```

--- a/examples/aws_group_mode_insane_mode_existing_vpc/main.tf
+++ b/examples/aws_group_mode_insane_mode_existing_vpc/main.tf
@@ -1,0 +1,34 @@
+data "aws_vpc" "example" {
+  id = var.vpc_id
+}
+
+data "aws_subnet" "example_gw" {
+  id = var.gw_subnet_id
+}
+
+data "aws_subnet" "example_hagw" {
+  id = var.hagw_subnet_id
+}
+
+module "spoke_aws_1" {
+  source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
+  version = "1.6.5"
+
+  cloud                  = "AWS"
+  name                   = "awsapp1"
+  region                 = "us-east-1"
+  account                = "aws-account"
+  transit_gw             = "avx-us-east-1-tg"
+  vpc_id                 = data.aws_vpc.example.vpc_id
+  gw_subnet              = data.aws_subnet.example_gw.cidr_block
+  hagw_subnet            = data.aws_subnet.example_hagw.cidr_block #Use separate subnets in multiple AZ's for gw and hagw, for multi AZ availability.
+  insane_mode            = true
+  use_existing_vpc       = true
+  inspection             = true
+
+  #Group mode settings 3 GW's, provide the additional subnet CIDR's for spoke gateways 3-n.
+  group_mode                    = true
+  spoke_gw_amount               = 3
+  additional_group_mode_subnets = ["10.1.0.0/26"]
+  additional_group_mode_azs     = ["c"]
+}

--- a/examples/aws_group_mode_insane_mode_existing_vpc/main.tf
+++ b/examples/aws_group_mode_insane_mode_existing_vpc/main.tf
@@ -14,17 +14,17 @@ module "spoke_aws_1" {
   source  = "terraform-aviatrix-modules/mc-spoke/aviatrix"
   version = "1.6.5"
 
-  cloud                  = "AWS"
-  name                   = "awsapp1"
-  region                 = "us-east-1"
-  account                = "aws-account"
-  transit_gw             = "avx-us-east-1-tg"
-  vpc_id                 = data.aws_vpc.example.vpc_id
-  gw_subnet              = data.aws_subnet.example_gw.cidr_block
-  hagw_subnet            = data.aws_subnet.example_hagw.cidr_block #Use separate subnets in multiple AZ's for gw and hagw, for multi AZ availability.
-  insane_mode            = true
-  use_existing_vpc       = true
-  inspection             = true
+  cloud            = "AWS"
+  name             = "awsapp1"
+  region           = "us-east-1"
+  account          = "aws-account"
+  transit_gw       = "avx-us-east-1-tg"
+  vpc_id           = data.aws_vpc.example.vpc_id
+  gw_subnet        = data.aws_subnet.example_gw.cidr_block
+  hagw_subnet      = data.aws_subnet.example_hagw.cidr_block #Use separate subnets in multiple AZ's for gw and hagw, for multi AZ availability.
+  insane_mode      = true
+  use_existing_vpc = true
+  inspection       = true
 
   #Group mode settings 3 GW's, provide the additional subnet CIDR's for spoke gateways 3-n.
   group_mode                    = true

--- a/locals.tf
+++ b/locals.tf
@@ -156,9 +156,9 @@ locals {
 
   instance_size = length(var.instance_size) > 0 ? var.instance_size : lookup(local.instance_size_map, local.cloud, null)
   instance_size_map = {
-    azure = "Standard_B1ms",
+    azure = "Standard_B2ms",
     aws   = "t3.medium",
-    gcp   = "n1-standard-1",
+    gcp   = "n1-highcpu-4",
     oci   = "VM.Standard2.2",
     ali   = "ecs.g5ne.large",
   }

--- a/locals.tf
+++ b/locals.tf
@@ -156,9 +156,9 @@ locals {
 
   instance_size = length(var.instance_size) > 0 ? var.instance_size : lookup(local.instance_size_map, local.cloud, null)
   instance_size_map = {
-    azure = "Standard_B2ms",
+    azure = "Standard_B1ms",
     aws   = "t3.medium",
-    gcp   = "n1-highcpu-4",
+    gcp   = "n1-standard-1",
     oci   = "VM.Standard2.2",
     ali   = "ecs.g5ne.large",
   }


### PR DESCRIPTION
change HPE instance size and add AWS example for group mode

<--- GCP

```
Error: failed to create Aviatrix Spoke Gateway: rest API create_multicloud_primary_gateway POST failed: [AVXERR-TRANSIT-0024] Failed to launch Gateway - gcpapp11. [AVXERR-GCE-0007] Google Cloud gateway gcpapp11 instance size is not supported with HPE mode. Only following instance sizes are supported ['n1-highcpu-4', 'n1-highcpu-8', 'n1-highcpu-16', 'n1-highcpu-32', 'n1-highcpu-64', 'n1-highcpu-96', 'n2-highcpu-4', 'n2-highcpu-8', 'n2-highcpu-16', 'n2-highcpu-32', 'n2-highcpu-64', 'n2-highcpu-96', 'c2-standard-4', 'c2-standard-8', 'c2-standard-16', 'c2-standard-30', 'c2-standard-60', 'n1-standard-4', 'n1-standard-8', 'n1-standard-16', 'n1-standard-32', 'n1-standard-64', 'n1-standard-96']
``` 
<--- Azure

```
Error: failed to create Aviatrix Spoke Gateway: rest API create_multicloud_primary_gateway POST failed: [AVXERR-TRANSIT-0024] Failed to launch Gateway - sp-1-azr-test. [AVXERR-TRANSIT-0061] Only following instance sizes are allowed when HPE mode is enabled: ['Standard_B2ms', 'Standard_D3_v2', 'Standard_D4_v2', 'Standard_D4_v3', 'Standard_D5_v2', 'Standard_DS3_v2', 'Standard_DS4_v2', 'Standard_DS5_v2', 'Standard_D4s_v3', 'Standard_D8_v3', 'Standard_D16_v3', 'Standard_D32_v3', 'Standard_D48_v3', 'Standard_D64_v3', 'Standard_D8s_v3', 'Standard_D16s_v3', 'Standard_D32s_v3', 'Standard_D48s_v3', 'Standard_D64s_v3', 'Standard_D2_v4', 'Standard_D4_v4', 'Standard_D2s_v4', 'Standard_D4s_v4', 'Standard_D8_v4', 'Standard_D16_v4', 'Standard_D32_v4', 'Standard_D48_v4', 'Standard_D64_v4', 'Standard_D8s_v4', 'Standard_D16s_v4', 'Standard_D32s_v4', 'Standard_D48s_v4', 'Standard_D64s_v4', 'Standard_D2_v5', 'Standard_D4_v5', 'Standard_D8_v5', 'Standard_D16_v5', 'Standard_D32_v5', 'Standard_D48_v5', 'Standard_D64_v5', 'Standard_D2ds_v5', 'Standard_D4ds_v5', 'Standard_D8ds_v5', 'Standard_D16ds_v5', 'Standard_D32ds_v5', 'Standard_D48ds_v5', 'Standard_D64ds_v5', 'Standard_D2s_v5', 'Standard_D4s_v5', 'Standard_D8s_v5', 'Standard_D16s_v5', 'Standard_D32s_v5', 'Standard_D48s_v5', 'Standard_D64s_v5', 'Standard_F4s_v2', 'Standard_F8s_v2', 'Standard_F16s_v2', 'Standard_F32s_v2', 'Standard_F48s_v2', 'Standard_F64s_v2', 'Standard_F72s_v2', 'Standard_F8', 'Standard_F16'].
``` 